### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.0.6</version>
+            <version>2.8.11</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION

Known high severity security vulnerability detected in com.fasterxml.jackson.core:jackson-databind < 2.8.11 defined in pom.xml.
--
pom.xml update suggested: com.fasterxml.jackson.core:jackson-databind ~> 2.8.11.

